### PR TITLE
Stephen auto login

### DIFF
--- a/Sources/FanMaker/FanMakerSDK.swift
+++ b/Sources/FanMaker/FanMakerSDK.swift
@@ -102,9 +102,6 @@ public class FanMakerSDK {
         if host.lowercased() == "fanmaker" {
             self.deepLinkPath = path
             
-            // Perform login before loading the URL
-            _ = self.loginUserFromParams()
-            
             if((self.currentWebView != nil) && (self.baseURL != nil)) {
                 let fullUrl = (self.baseURL ?? String("")) + path
                 let url = URL(string: fullUrl)!
@@ -270,7 +267,7 @@ public class FanMakerSDK {
         var success = false
 
         // Make the API request
-        FanMakerSDKHttp.post(sdk: self, path: "/site/auth/auto_login", body: identifiers) { result in
+        FanMakerSDKHttp.post(sdk: self, path: "/site/auth/auto_login", body: identifiers, useSiteApiToken: true) { result in
             switch result {
             case .success(let response):
                 if response.status == 200 {
@@ -281,8 +278,9 @@ public class FanMakerSDK {
                     }
                 }
             case .failure(let error):
-                NSLog("FanMaker loginUserFromParams failed with error: \(error.localizedDescription)")
+                print("Login failed with error: \(error)")
             }
+            
             semaphore.signal()
         }
 
@@ -328,7 +326,6 @@ public class FanMakerSDK {
 
         self.fanmakerIdentifierLexicon = idLexicon
 
-        loginUserFromParams()
         return self.fanmakerIdentifierLexicon as? [String: Any] ?? [:]
     }
 

--- a/Sources/FanMaker/FanMakerSDKWebView.swift
+++ b/Sources/FanMaker/FanMakerSDKWebView.swift
@@ -53,6 +53,8 @@ public struct FanMakerSDKWebView : UIViewRepresentable {
     }
 
     public func prepareUIView() {
+        // Perform login before preparing the webview
+        _ = sdk.loginUserFromParams()
 
         var urlString = self.urlString
         let url : URL? = URL(string: urlString)

--- a/Sources/FanMaker/FanMakerSDKWebView.swift
+++ b/Sources/FanMaker/FanMakerSDKWebView.swift
@@ -114,6 +114,7 @@ public struct FanMakerSDKWebView : UIViewRepresentable {
         // Convert the JSON data to a string
         let jsonUserTokenString = String(data: jsonFanmakerUserToken, encoding: .utf8)
         // Set the JSON string as the value for the HTTP header field
+        NSLog("-------------------------------- FanMaker User Token: \(jsonUserTokenString)")
         request.setValue(jsonUserTokenString, forHTTPHeaderField: "X-FanMaker-User-Token")
         // ------------------------------------------------------------ <<< FanMaker User Token
 

--- a/Sources/FanMaker/FanMakerSDKWebView.swift
+++ b/Sources/FanMaker/FanMakerSDKWebView.swift
@@ -114,7 +114,6 @@ public struct FanMakerSDKWebView : UIViewRepresentable {
         // Convert the JSON data to a string
         let jsonUserTokenString = String(data: jsonFanmakerUserToken, encoding: .utf8)
         // Set the JSON string as the value for the HTTP header field
-        NSLog("-------------------------------- FanMaker User Token: \(jsonUserTokenString)")
         request.setValue(jsonUserTokenString, forHTTPHeaderField: "X-FanMaker-User-Token")
         // ------------------------------------------------------------ <<< FanMaker User Token
 

--- a/Sources/FanMaker/FanMakerSDKWebViewController.swift
+++ b/Sources/FanMaker/FanMakerSDKWebViewController.swift
@@ -229,9 +229,6 @@ public struct FanMakerSDKWebViewControllerRepresentable : UIViewControllerRepres
     }
 
     public func makeUIViewController(context: Context) -> some UIViewController {
-        // Perform login before creating the web view controller
-        _ = sdk.loginUserFromParams()
-        
         return FanMakerSDKWebViewController(sdk: sdk)
     }
 

--- a/Sources/FanMaker/FanMakerSDKWebViewController.swift
+++ b/Sources/FanMaker/FanMakerSDKWebViewController.swift
@@ -229,6 +229,9 @@ public struct FanMakerSDKWebViewControllerRepresentable : UIViewControllerRepres
     }
 
     public func makeUIViewController(context: Context) -> some UIViewController {
+        // Perform login before creating the web view controller
+        _ = sdk.loginUserFromParams()
+        
         return FanMakerSDKWebViewController(sdk: sdk)
     }
 

--- a/Sources/FanMaker/Http/FanMakerSDKHttp.swift
+++ b/Sources/FanMaker/Http/FanMakerSDKHttp.swift
@@ -19,4 +19,10 @@ public struct FanMakerSDKHttp {
         let request = FanMakerSDKHttpRequest(sdk: sdk, path: path)
         request.request(method: "POST", body: body, model: FanMakerSDKPostResponse.self, onCompletion: onCompletion)
     }
+    
+    public static func post(sdk: FanMakerSDK, path: String, body: Any, useSiteApiToken: Bool, onCompletion: @escaping (Result<FanMakerSDKPostResponse, FanMakerSDKHttpError>) -> Void) {
+
+        let request = FanMakerSDKHttpRequest(sdk: sdk, path: path)
+        request.request(method: "POST", body: body, useSiteApiToken: useSiteApiToken, model: FanMakerSDKPostResponse.self, onCompletion: onCompletion)
+    }
 }


### PR DESCRIPTION
This pull request introduces several updates to the `FanMakerSDK` to improve API request handling, streamline login processes, and enhance flexibility in token usage. The most significant changes include the addition of a new API method to support site-specific API tokens, the removal of redundant login calls, and updates to error logging for better debugging.

### API Enhancements:
* Added a new `post` method in `FanMakerSDKHttp` to support an optional `useSiteApiToken` parameter, allowing requests to explicitly use the site API token for authorization. (`Sources/FanMaker/Http/FanMakerSDKHttp.swift`, [Sources/FanMaker/Http/FanMakerSDKHttp.swiftR22-R27](diffhunk://#diff-f66e19468ba0a90c5246733e155d006d70ac93b1b0925061433c33f6ea2b5117R22-R27))
* Updated `FanMakerSDKHttpRequest` to handle the `useSiteApiToken` parameter. When enabled, the `Authorization` and `X-FanMaker-Token` headers are set to the API key; otherwise, the session token is used if available. (`Sources/FanMaker/Http/FanMakerSDKHttpRequest.swift`, [[1]](diffhunk://#diff-cebf707997a6d64780631d4696040906afc95dfb1d031f4c888e900020506ec5R28-R31) [[2]](diffhunk://#diff-cebf707997a6d64780631d4696040906afc95dfb1d031f4c888e900020506ec5R52-R57) [[3]](diffhunk://#diff-cebf707997a6d64780631d4696040906afc95dfb1d031f4c888e900020506ec5R66)

### Login Process Simplification:
* Removed redundant calls to `loginUserFromParams` in `FanMakerSDK` methods, simplifying the SDK's internal workflow. (`Sources/FanMaker/FanMakerSDK.swift`, [[1]](diffhunk://#diff-cc9127c57f57554090eedd45176b67636fe10140da7ac65effd671a1322d084cL105-L107) [[2]](diffhunk://#diff-cc9127c57f57554090eedd45176b67636fe10140da7ac65effd671a1322d084cL331)
* Moved the `loginUserFromParams` call to the `prepareUIView` method in `FanMakerSDKWebView`, ensuring login is performed before preparing the web view. (`Sources/FanMaker/FanMakerSDKWebView.swift`, [Sources/FanMaker/FanMakerSDKWebView.swiftR56-R57](diffhunk://#diff-b56a08ed04a1d49696ef4a9c6976df0e3146152d17f744ef1f99529aec2c41e1R56-R57))

### Debugging Improvements:
* Replaced `NSLog` with `print` for error logging in `loginUserFromParams`, providing a more concise and readable output. (`Sources/FanMaker/FanMakerSDK.swift`, [Sources/FanMaker/FanMakerSDK.swiftL284-R283](diffhunk://#diff-cc9127c57f57554090eedd45176b67636fe10140da7ac65effd671a1322d084cL284-R283))