### PR TITLE
allow us to refresh oauth tokens and default to dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,12 @@ The SDK will:
 **Note**: The `params` dictionary contains any parameters passed from the web view. Actions are handled dynamically, so you can add new actions without updating the SDK code.
 
 ### Loading Animation | Light vs Dark
-By default the FanMaker SDK will use a Light loading animated view when initializing the FanMaker SDK. There is an optional Dark loading animated view that you can use instead:
+By default the FanMaker SDK will use a Dark loading animated view when initializing the FanMaker SDK. If your application uses a light theme, you can disable the dark loading screen:
+```
+AppDelegate.fanmakerSDK1.disableDarkLoadingScreen()
+```
+
+To re-enable it:
 ```
 AppDelegate.fanmakerSDK1.enableDarkLoadingScreen()
 ```

--- a/Sources/FanMaker/FanMakerSDKWebViewController.swift
+++ b/Sources/FanMaker/FanMakerSDKWebViewController.swift
@@ -52,27 +52,27 @@ open class FanMakerSDKWebViewController : UIViewController, WKScriptMessageHandl
             loadingAnimation.image = fgImage
         } else {
             if self.sdk.useDarkLoadingScreen {
-                var images : [UIImage] = []
-                for index in 0...21 {
-                    if let path = Bundle.module.path(forResource: "fanmaker-sdk-dark-loading-\(index)", ofType: "png") {
-                        if let image = UIImage(contentsOfFile: path) {
-                            images.append(image)
-                        }
-                    }
-                }
-                loadingAnimation.image = UIImage.animatedImage(with: images, duration: 1.0)
+                // var images : [UIImage] = []
+                // for index in 0...21 {
+                //     if let path = Bundle.module.path(forResource: "fanmaker-sdk-dark-loading-\(index)", ofType: "png") {
+                //         if let image = UIImage(contentsOfFile: path) {
+                //             images.append(image)
+                //         }
+                //     }
+                // }
+                // loadingAnimation.image = UIImage.animatedImage(with: images, duration: 1.0)
                 self.view.backgroundColor = UIColor(red: 0.102, green: 0.102, blue: 0.102, alpha: 1.00)
             }
             else {
-                var images : [UIImage] = []
-                for index in 0...29 {
-                    if let path = Bundle.module.path(forResource: "fanmaker-sdk-loading-\(index)", ofType: "png") {
-                        if let image = UIImage(contentsOfFile: path) {
-                            images.append(image)
-                        }
-                    }
-                }
-                loadingAnimation.image = UIImage.animatedImage(with: images, duration: 1.0)
+                // var images : [UIImage] = []
+                // for index in 0...29 {
+                //     if let path = Bundle.module.path(forResource: "fanmaker-sdk-loading-\(index)", ofType: "png") {
+                //         if let image = UIImage(contentsOfFile: path) {
+                //             images.append(image)
+                //         }
+                //     }
+                // }
+                // loadingAnimation.image = UIImage.animatedImage(with: images, duration: 1.0)
             }
         }
 
@@ -97,6 +97,8 @@ open class FanMakerSDKWebViewController : UIViewController, WKScriptMessageHandl
                     if let token = value as? String {
                         defaults?.set(token, forKey: self.sdk.FanMakerSDKSessionToken)
                     }
+                    var dict: [String: Any] = [:]
+                    print("FanMaker ---------------------------------------------------------- Set Session Token Received")
                 case "setIdentifiers":
                     if let token = value as? String {
                         self.sdk.setIdentifiers(fromJSON: token)
@@ -162,6 +164,9 @@ open class FanMakerSDKWebViewController : UIViewController, WKScriptMessageHandl
                             case "identifiers":
                                 var val = self.sdk.valueForKey(forKey: "fanmakerIdentifierLexicon")
                                 fanmaker!.webView.evaluateJavaScript(val)
+                            case "userToken":
+                                var val = self.sdk.valueForKey(forKey: "fanmakerUserToken")
+                                fanmaker!.webView.evaluateJavaScript(val)
                             case "params":
                                 var val = self.sdk.valueForKey(forKey: "fanmakerParametersLexicon")
                                 fanmaker!.webView.evaluateJavaScript(val)
@@ -213,6 +218,10 @@ open class FanMakerSDKWebViewController : UIViewController, WKScriptMessageHandl
                 case "fetchJSONValue":
                     if let value = value as? String {
                         switch value {
+                            case "sessionToken":
+                                let sessionToken = self.sdk.sessionToken ?? ""
+                                let escapedToken = sessionToken.replacingOccurrences(of: "\"", with: "\\\"")
+                                fanmaker!.webView.evaluateJavaScript("FanmakerSDKCallback(\"\(escapedToken)\")")
                             case "locationServicesEnabled":
                                 var authorizationStatus: CLAuthorizationStatus
                                 if #available(iOS 14.0, *) {

--- a/Sources/FanMaker/Http/FanMakerSDKHttpError.swift
+++ b/Sources/FanMaker/Http/FanMakerSDKHttpError.swift
@@ -14,6 +14,7 @@ public struct FanMakerSDKHttpError : LocalizedError, Sendable {
         case badData = 3
         case badResponse = 4
         case unknown = 5
+        case tokenRefreshFailed = 6
         case success = 200
         case forbidden = 401
         case notFound = 404

--- a/Sources/FanMaker/Http/FanMakerSDKToken.swift
+++ b/Sources/FanMaker/Http/FanMakerSDKToken.swift
@@ -1,0 +1,306 @@
+//
+//  FanMakerSDKToken.swift
+//
+//  Universal token type detection, expiration checking, and OAuth refresh support.
+//
+
+import Foundation
+
+// MARK: - OAuth Token Data Model
+
+/// Represents the parsed JSON payload of an OAuth access token from Doorkeeper.
+/// `expires_at` is optional because standard Doorkeeper responses don't include it;
+/// when missing it is computed from `created_at + expires_in`.
+public struct FanMakerSDKOAuthToken: Codable {
+    public let access_token: String
+    public let refresh_token: String
+    public let expires_in: Int
+    public let created_at: Int
+
+    /// May be provided directly (e.g. from ApiTokenGenerator) or computed.
+    private let _expires_at: Int?
+
+    public var expires_at: Int {
+        return _expires_at ?? (created_at + expires_in)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case access_token, refresh_token, expires_in, created_at
+        case _expires_at = "expires_at"
+    }
+
+    /// Returns a JSON string representation suitable for storing back in UserDefaults
+    /// or sending as a header value. Always includes `expires_at` (computed if needed).
+    public func toJSONString() -> String? {
+        // Build a dictionary so we always include expires_at in the output,
+        // even if it was computed from created_at + expires_in.
+        let dict: [String: Any] = [
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "expires_in": expires_in,
+            "expires_at": expires_at,
+            "created_at": created_at
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: dict) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}
+
+// MARK: - Token Type Enum
+
+/// Represents the two possible token types the SDK may encounter.
+public enum FanMakerSDKTokenType {
+    /// A plain API token string (e.g., "a8df7897dfaiod7faehrl")
+    case apiToken(String)
+    /// An OAuth token parsed from a JSON string
+    case oauthToken(FanMakerSDKOAuthToken)
+}
+
+// MARK: - Token Resolver
+
+/// Utility for detecting token types, checking expiration, building header values,
+/// and refreshing expired OAuth tokens via Doorkeeper.
+///
+/// Refresh requests are coalesced: if multiple callers request a refresh at the same time,
+/// only one network request is made and the result is shared with all waiting callers.
+public class FanMakerSDKTokenResolver {
+
+    /// Buffer in seconds before `expires_at` to consider the token expired,
+    /// avoiding edge-case races where the token expires mid-flight.
+    private static let expirationBufferSeconds: TimeInterval = 30
+
+    // MARK: - Refresh Coalescing State
+
+    /// Lock protecting the refresh queue state.
+    private static let refreshLock = NSLock()
+    /// Whether a refresh network request is currently in-flight.
+    private static var isRefreshing = false
+    /// Queued completions waiting for the in-flight refresh to finish.
+    private static var pendingRefreshCompletions: [(Result<FanMakerSDKOAuthToken, FanMakerSDKHttpError>) -> Void] = []
+
+    // MARK: - Token Type Detection
+
+    /// Attempts to parse the token string as an OAuth JSON payload.
+    /// Falls back to `.apiToken` if JSON decoding fails.
+    public static func resolve(_ tokenString: String) -> FanMakerSDKTokenType {
+        guard let data = tokenString.data(using: .utf8) else {
+            NSLog("FanMaker ######################################################################## Token Type: API Token")
+            return .apiToken(tokenString)
+        }
+
+        do {
+            let oauthToken = try JSONDecoder().decode(FanMakerSDKOAuthToken.self, from: data)
+            NSLog("FanMaker ######################################################################## Token Type: OAuth Access Token (expired: \(isExpired(oauthToken) ? "YES" : "NO"))")
+            return .oauthToken(oauthToken)
+        } catch {
+            NSLog("FanMaker ######################################################################## Token Type: API Token")
+            return .apiToken(tokenString)
+        }
+    }
+
+    // MARK: - Expiration Check
+
+    /// Returns `true` if the OAuth token has expired (or will expire within the buffer window).
+    public static func isExpired(_ token: FanMakerSDKOAuthToken) -> Bool {
+        let expiresAtDate = Date(timeIntervalSince1970: TimeInterval(token.expires_at))
+        let bufferedExpiration = expiresAtDate.addingTimeInterval(-expirationBufferSeconds)
+        return Date() >= bufferedExpiration
+    }
+
+    // MARK: - Header Value Builders
+
+    /// Returns the value for the `Authorization` header.
+    /// - For OAuth tokens: `"Bearer <access_token>"` (checks if `Bearer` is already present)
+    /// - For API tokens: the raw token string as-is
+    public static func authorizationHeaderValue(for tokenType: FanMakerSDKTokenType) -> String {
+        switch tokenType {
+        case .apiToken(let token):
+            return token
+        case .oauthToken(let oauthToken):
+            let accessToken = oauthToken.access_token
+            if accessToken.lowercased().hasPrefix("bearer ") {
+                return accessToken
+            }
+            return "Bearer \(accessToken)"
+        }
+    }
+
+    /// Returns the value for the `X-FanMaker-SessionToken` header.
+    /// - For OAuth tokens: the full original JSON string (receiver will JSON decode it)
+    /// - For API tokens: the raw token string as-is
+    public static func sessionTokenHeaderValue(for tokenType: FanMakerSDKTokenType, rawTokenString: String) -> String {
+        switch tokenType {
+        case .apiToken(let token):
+            return token
+        case .oauthToken(let oauthToken):
+            // Prefer re-encoding the token to ensure consistency after a refresh,
+            // but fall back to the raw string if encoding fails.
+            return oauthToken.toJSONString() ?? rawTokenString
+        }
+    }
+
+    // MARK: - Token Refresh (Coalesced)
+
+    /// Enqueues a refresh request. If a refresh is already in-flight, the completion
+    /// is queued and will be called with the result of the in-flight request.
+    /// Only one network request is made regardless of how many callers need a refresh.
+    private static func enqueueRefresh(
+        _ token: FanMakerSDKOAuthToken,
+        apiBase: String,
+        completion: @escaping (Result<FanMakerSDKOAuthToken, FanMakerSDKHttpError>) -> Void
+    ) {
+        refreshLock.lock()
+
+        if isRefreshing {
+            // A refresh is already in-flight -- just queue up and wait
+            let queueSize = pendingRefreshCompletions.count + 1
+            NSLog("FanMaker ######################################################################## Refresh already in-flight, queuing caller (\(queueSize) waiting)")
+            pendingRefreshCompletions.append(completion)
+            refreshLock.unlock()
+            return
+        }
+
+        // We're the first -- mark as refreshing and go
+        isRefreshing = true
+        refreshLock.unlock()
+
+        executeRefresh(token, apiBase: apiBase) { result in
+            // Grab all pending completions and reset state
+            refreshLock.lock()
+            let waitingCompletions = pendingRefreshCompletions
+            pendingRefreshCompletions = []
+            isRefreshing = false
+            refreshLock.unlock()
+
+            let totalCallers = waitingCompletions.count + 1
+            NSLog("FanMaker ######################################################################## Refresh complete, notifying \(totalCallers) caller(s)")
+
+            // Notify the original caller
+            completion(result)
+            // Notify all queued callers with the same result
+            for waiting in waitingCompletions {
+                waiting(result)
+            }
+        }
+    }
+
+    /// Executes the actual network request to refresh the OAuth token.
+    /// Only called by `enqueueRefresh` -- never directly.
+    private static func executeRefresh(
+        _ token: FanMakerSDKOAuthToken,
+        apiBase: String,
+        completion: @escaping (Result<FanMakerSDKOAuthToken, FanMakerSDKHttpError>) -> Void
+    ) {
+        let urlString = "\(apiBase)/oauth/token"
+        guard let url = URL(string: urlString) else {
+            completion(.failure(FanMakerSDKHttpError(code: .badUrl, message: urlString)))
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let body: [String: String] = [
+            "grant_type": "refresh_token",
+            "refresh_token": token.refresh_token
+        ]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        } catch {
+            completion(.failure(FanMakerSDKHttpError(code: .badData, message: "Failed to serialize refresh token request body")))
+            return
+        }
+
+        NSLog("FanMaker ######################################################################## Refresh starting: POST \(urlString)")
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                NSLog("FanMaker ######################################################################## Refresh ERROR (network): \(error.localizedDescription)")
+                completion(.failure(FanMakerSDKHttpError(code: .tokenRefreshFailed, message: "Token refresh network error: \(error.localizedDescription)")))
+                return
+            }
+
+            guard let httpResponse = response as? HTTPURLResponse, let data = data else {
+                NSLog("FanMaker ######################################################################## Refresh ERROR: no response or data")
+                completion(.failure(FanMakerSDKHttpError(code: .tokenRefreshFailed, message: "Invalid response from token refresh")))
+                return
+            }
+
+            // Always dump the raw response body so we can debug decode issues
+            let rawBody = String(data: data, encoding: .utf8) ?? "(could not decode body as UTF-8)"
+            NSLog("FanMaker ######################################################################## Refresh response HTTP \(httpResponse.statusCode)")
+            NSLog("FanMaker ######################################################################## Refresh response body: \(rawBody)")
+
+            guard httpResponse.statusCode == 200 else {
+                var errorMessage = "Token refresh failed with HTTP \(httpResponse.statusCode)"
+                if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let doorkeeperError = json["error"] as? String {
+                    errorMessage += ": \(doorkeeperError)"
+                    if let description = json["error_description"] as? String {
+                        errorMessage += " - \(description)"
+                    }
+                }
+                NSLog("FanMaker ######################################################################## Refresh ERROR: \(errorMessage)")
+                completion(.failure(FanMakerSDKHttpError(code: .tokenRefreshFailed, message: errorMessage)))
+                return
+            }
+
+            do {
+                let newToken = try JSONDecoder().decode(FanMakerSDKOAuthToken.self, from: data)
+                NSLog("FanMaker ######################################################################## Refresh SUCCESS - new token expires_at: \(newToken.expires_at)")
+                completion(.success(newToken))
+            } catch {
+                NSLog("FanMaker ######################################################################## Refresh ERROR (decode): \(error.localizedDescription)")
+                NSLog("FanMaker ######################################################################## Refresh ERROR (decode detail): \(error)")
+                completion(.failure(FanMakerSDKHttpError(code: .tokenRefreshFailed, message: "Failed to decode refreshed token: \(error.localizedDescription)")))
+            }
+        }.resume()
+    }
+
+    // MARK: - High-Level Token Resolution
+
+    /// Resolves the token type, checks expiration for OAuth tokens, refreshes if needed,
+    /// and returns a valid token type ready to use for headers.
+    ///
+    /// - Parameters:
+    ///   - tokenString: The raw token string from UserDefaults
+    ///   - apiBase: The base URL for the API (e.g., "http://api3.fanmaker.work:3002")
+    ///   - onRefreshed: Called with the new JSON string when a token is refreshed,
+    ///                  so the caller can persist it back to storage
+    ///   - completion: Called with the valid token type or an error
+    public static func getValidToken(
+        tokenString: String,
+        apiBase: String,
+        onRefreshed: @escaping (String) -> Void,
+        completion: @escaping (Result<FanMakerSDKTokenType, FanMakerSDKHttpError>) -> Void
+    ) {
+        let tokenType = resolve(tokenString)
+
+        switch tokenType {
+        case .apiToken:
+            completion(.success(tokenType))
+
+        case .oauthToken(let oauthToken):
+            if !isExpired(oauthToken) {
+                completion(.success(tokenType))
+            } else {
+                // Token is expired -- enqueue refresh (coalesced with other callers)
+                enqueueRefresh(oauthToken, apiBase: apiBase) { result in
+                    switch result {
+                    case .success(let newToken):
+                        // Notify caller so they can persist the new token
+                        if let newJsonString = newToken.toJSONString() {
+                            onRefreshed(newJsonString)
+                        }
+                        completion(.success(.oauthToken(newToken)))
+
+                    case .failure(let error):
+                        completion(.failure(error))
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request makes several significant updates to the FanMaker SDK, focusing on improving token handling, session management, theming, and general code maintenance. The most notable changes include switching the default loading theme to dark, enhancing session token management and OAuth handling, updating HTTP request headers to reflect theme preferences, and cleaning up deprecated OAuth code.

**Theme and Loading Screen Improvements**
- The SDK now uses a dark loading animation by default. Developers can disable or re-enable the dark loading screen via new methods `disableDarkLoadingScreen()` and `enableDarkLoadingScreen()`. The documentation (`README.md`) has been updated to reflect this new behavior. (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L374-R379)`, `[[2]](diffhunk://#diff-cc9127c57f57554090eedd45176b67636fe10140da7ac65effd671a1322d084cL59-R59)`, `[[3]](diffhunk://#diff-cc9127c57f57554090eedd45176b67636fe10140da7ac65effd671a1322d084cR380-R383)`)
- HTTP requests from the SDK now include a new header (`X-Fanmaker-Theme`) that communicates the current theme preference (`dark` or `light`) based on the SDK’s configuration. (`[Sources/FanMaker/FanMakerSDKWebView.swiftL122-R154](diffhunk://#diff-b56a08ed04a1d49696ef4a9c6976df0e3146152d17f744ef1f99529aec2c41e1L122-R154)`)
- The SDK version sent in HTTP headers is updated to `4.0.0`. (`[Sources/FanMaker/FanMakerSDKWebView.swiftL122-R154](diffhunk://#diff-b56a08ed04a1d49696ef4a9c6976df0e3146152d17f744ef1f99529aec2c41e1L122-R154)`)

**Session Token and OAuth Management**
- Introduced new computed properties and methods for session token persistence (`sessionToken`, `updateSessionToken`). These changes improve how tokens are stored and refreshed, and allow seamless token updates after OAuth refreshes. (`[Sources/FanMaker/FanMakerSDK.swiftL502-R507](diffhunk://#diff-cc9127c57f57554090eedd45176b67636fe10140da7ac65effd671a1322d084cL502-R507)`)
- WebView requests now resolve and refresh tokens as needed using `FanMakerSDKTokenResolver`, automatically updating stored tokens and setting both `X-FanMaker-SessionToken` and `Authorization` headers. (`[Sources/FanMaker/FanMakerSDKWebView.swiftL64-R96](diffhunk://#diff-b56a08ed04a1d49696ef4a9c6976df0e3146152d17f744ef1f99529aec2c41e1L64-R96)`)
- The WebView controller now supports fetching the session token via JavaScript bridge, enabling web-based components to access the current session token. (`[[1]](diffhunk://#diff-72d4de4227fa523e3223775e1549ef01cb5a160f952d985bb576dcfb279b93e3R167-R169)`, `[[2]](diffhunk://#diff-72d4de4227fa523e3223775e1549ef01cb5a160f952d985bb576dcfb279b93e3R221-R224)`)

**Code Cleanup and Maintenance**
- All deprecated and unused OAuth code has been removed from the SDK, simplifying the codebase and reducing confusion about future OAuth support. (`[[1]](diffhunk://#diff-cc9127c57f57554090eedd45176b67636fe10140da7ac65effd671a1322d084cL96-L101)`, `[[2]](diffhunk://#diff-cc9127c57f57554090eedd45176b67636fe10140da7ac65effd671a1322d084cL184-L197)`, `[[3]](diffhunk://#diff-cc9127c57f57554090eedd45176b67636fe10140da7ac65effd671a1322d084cL502-R507)`)
- The loading animation code for both dark and light themes in `FanMakerSDKWebViewController` has been commented out, possibly as a step toward a new animation implementation. (`[Sources/FanMaker/FanMakerSDKWebViewController.swiftL55-R75](diffhunk://#diff-72d4de4227fa523e3223775e1549ef01cb5a160f952d985bb576dcfb279b93e3L55-R75)`)

**Logging and Debugging Enhancements**
- Improved logging for auto-login attempts, including detailed success/failure messages and token status, to aid in debugging authentication flows. (`[Sources/FanMaker/FanMakerSDK.swiftR284-R306](diffhunk://#diff-cc9127c57f57554090eedd45176b67636fe10140da7ac65effd671a1322d084cR284-R306)`)
- Added a debug print statement when setting the session token in the WebView controller. (`[Sources/FanMaker/FanMakerSDKWebViewController.swiftR100-R101](diffhunk://#diff-72d4de4227fa523e3223775e1549ef01cb5a160f952d985bb576dcfb279b93e3R100-R101)`)

**Error Handling**
- Added a new error case (`tokenRefreshFailed`) to the `FanMakerSDKHttpError` enum, supporting better error reporting for token refresh failures. (`[Sources/FanMaker/Http/FanMakerSDKHttpError.swiftR17](diffhunk://#diff-4d085a033e404e4c09f6c3d9e62cea3ae2a88f4aac81c25e52e065b3c5909d2eR17)`)